### PR TITLE
Shirt+Tab : remove indentation of the line

### DIFF
--- a/src/haxe/ui/richtext/Code.hx
+++ b/src/haxe/ui/richtext/Code.hx
@@ -96,7 +96,7 @@ class Code extends TextInput {
 			replaceSelectedText("    ");
 			applyRules();
 		}
-		/* Handle Shift+Tab : this wi*/
+		/* Handle Shift+Tab : this will remove the first /t of the line*/
 		else if (event.keyCode == 9 && event.ctrlKey == false && event.altKey == false && event.shiftKey == true)
 		{
 


### PR DESCRIPTION
The added code allow the user to remove the indentation when he place his cursor at the beginning of a line and press Shit+Tab. 

It's try to remove 4 spaces at max.
